### PR TITLE
Data root flag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+tag-version-prefix=""
+package-lock=false
+message="chore(release): %s :tada:"

--- a/bin/araconf
+++ b/bin/araconf
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const { resolve } = require('path')
 const { error } = require('ara-console')
 const { name } = require('../package.json')
 const program = require('yargs')
@@ -11,6 +12,9 @@ const { argv } = program
   .usage('usage: $0 [-hV] [options] [query]')
   .alias('h', 'help')
   .alias('V', 'version')
+  .option('data-root', {
+    describe: 'Output data root directories',
+  })
   .option('D', {
     type: 'boolean',
     alias: 'debug',
@@ -32,8 +36,18 @@ delete conf.configs
 delete conf.config
 delete conf._
 
+delete conf['data-root']
+
 try {
-  if (argv._.length) {
+  if (argv['data-root']) {
+    if (true === argv['data-root']) {
+      process.stdout.write(conf.data.root)
+    } else {
+      process.stdout.write(resolve(conf.data.root, argv['data-root']))
+    }
+
+    process.stdout.write('\n')
+  } else if (argv._.length) {
     const stream = select(argv._.join(' '))
     stream.on('error', onfatal)
     stream.on('data', ondata)


### PR DESCRIPTION
Introduces `araconf --data-root [path]` command to output fully resolved paths found in the "data root" of the ara runtime configuration directory. This can be useful for outputting bin directories like:

```sh
$ araconf --data-root bin/
/home/werle/.ara/bin
```

## Proposed Changes

  - Add new `--data-root` flag that emits the data root directory without an argument or a resolved path in the data root based on the supplied argument