### PR TITLE
refactor(index.js): Clean up defaults object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,31 @@
 const { resolve } = require('path')
 const extend = require('extend')
+const debug = require('debug')('ara:runtime:configuration')
 const rc = require('rc')
 const os = require('os')
 
-const kRuntimeConfigurationName = 'ara'
+const RUNTIME_CONFIGURATION_NAME = 'ara'
+const ARA_DIR = resolve(os.homedir(), '.ara')
 
-const kRuntimeConfigurationDefaults = {
-  network: { 
-    identity: { 
-      root: resolve(os.homedir(), '.ara', 'identities'),
-      keyring: resolve(os.homedir(), '.ara', 'keyrings', 'keyring')
-    } 
+/**
+ * Top level keys are as follows-
+ * network
+ * data
+ * web3
+ */
+
+const RUNTIME_CONFIGURATION_DEFAULTS = {
+  network: {
+    identity: {
+      root: resolve(ARA_DIR, 'identities'),
+      get keyring() {
+        debug('Deprecated: network.identity.keyring will be set differently.')
+        return resolve(ARA_DIR, 'keyrings', 'keyring')
+      }
+    }
   },
-  data: { root: resolve(os.homedir(), '.ara') },
+  data: { root: ARA_DIR },
+  web3: { }
 }
 
 const state = {}
@@ -34,12 +47,12 @@ function ARARuntimeConfiguration(conf, name) {
   } else if (name && 'string' !== typeof name) {
     throw new TypeError('Expecting name to be a string.')
   } else {
-    const defaults = kRuntimeConfigurationDefaults
+    const defaults = RUNTIME_CONFIGURATION_DEFAULTS
     // use an empty argv because the 'rc' module uses
     // 'process.argv' if we don't give it one
     const argv = {}
     // eslint-disable-next-line no-param-reassign
-    name = name || kRuntimeConfigurationName
+    name = name || RUNTIME_CONFIGURATION_NAME
     // eslint-disable-next-line no-param-reassign
     conf = rc(name, extend(true, {}, defaults, conf), argv)
     extend(true, state, conf)


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - 3 top level keys:
    - network
    - data
    - web3
  - capitalize default variables
  - deprecate `network.identity.keyring`