### PR TITLE
Bap base function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Example [`.ararc`](/example/.ararc)
 
 ## API
 
-### `const conf = rc({defaults})`
+### `const conf = rc(conf, name)`
 
 Load runtime configuration defined in the nearest `.ararc` file on disk
 optionally specifying defaults.
 
-* `defaults` - Optional configuration defaults object.
-
+* `conf` - Optional default configuration object or function. If `conf` is a function, it will be passed the base runtime config object.
+* `name` - Optional name to override default `ara` rc name
 
 ### `araconf(1)`
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const { resolve } = require('path')
 const extend = require('extend')
-const debug = require('debug')('ara:runtime:configuration')
 const rc = require('rc')
 const os = require('os')
 
@@ -15,18 +14,20 @@ const ARA_DIR = resolve(os.homedir(), '.ara')
  */
 
 const RUNTIME_CONFIGURATION_DEFAULTS = {
-  network: {
-    identity: {
-      root: resolve(ARA_DIR, 'identities')
-    }
-  },
+  network: { },
   data: { root: ARA_DIR },
   web3: { }
 }
 
-const state = {}
+const NETWORK_CONFIGURATION_EXTENSION = base => ({
+  network: {
+    identity: {
+      root: resolve(base.data.root, 'identities')
+    }
+  }
+})
 
-module.exports = ARARuntimeConfiguration
+module.exports = AraRuntimeConfiguration
 
 /**
  * Return runtime configuration found in the nearest
@@ -37,21 +38,22 @@ module.exports = ARARuntimeConfiguration
  * @return {Object}
  * @see
  */
-function ARARuntimeConfiguration(conf, name) {
-  if (undefined !== conf && null !== conf && 'object' !== typeof conf) {
-    throw new TypeError('Expecting configuration to be an object.')
+function AraRuntimeConfiguration(conf, name) {
+  if (undefined !== conf && null !== conf && 'object' !== typeof conf && 'function' !== typeof conf) {
+    throw new TypeError('Expecting configuration to be an object or function.')
   } else if (name && 'string' !== typeof name) {
     throw new TypeError('Expecting name to be a string.')
   } else {
-    const defaults = RUNTIME_CONFIGURATION_DEFAULTS
     // use an empty argv because the 'rc' module uses
     // 'process.argv' if we don't give it one
     const argv = {}
     // eslint-disable-next-line no-param-reassign
     name = name || RUNTIME_CONFIGURATION_NAME
-    // eslint-disable-next-line no-param-reassign
-    conf = rc(name, extend(true, {}, defaults, conf), argv)
-    extend(true, state, conf)
-    return state
+
+    const baseConf = extend(true, {}, rc(name, RUNTIME_CONFIGURATION_DEFAULTS, argv))
+    extend(true, baseConf, NETWORK_CONFIGURATION_EXTENSION(baseConf))
+    extend(true, baseConf, ('function' === typeof conf) ? conf(baseConf) : conf)
+
+    return baseConf
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const ARA_DIR = resolve(os.homedir(), '.ara')
  */
 
 const RUNTIME_CONFIGURATION_DEFAULTS = {
-  network: { },
+  network: { identity: { } },
   data: { root: ARA_DIR },
   web3: { }
 }
@@ -22,7 +22,7 @@ const RUNTIME_CONFIGURATION_DEFAULTS = {
 const NETWORK_CONFIGURATION_EXTENSION = base => ({
   network: {
     identity: {
-      root: resolve(base.data.root, 'identities')
+      root: base.network.identity.root || resolve(base.data.root, 'identities')
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ara-runtime-configuration",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ARA Runtime Configuration (.ararc)",
   "main": "index.js",
   "browser": "browser.js",

--- a/test.js
+++ b/test.js
@@ -11,6 +11,20 @@ test.cb('simple', (t) => {
 
   t.true('function' === typeof rc)
   t.true('object' === typeof rc())
+  t.true('object' === typeof rc(() => {}))
   t.true(123 === rc({ foo: 123 }).foo)
   t.end()
+})
+
+test('function.valid', (t) => {
+  const conf = rc((base) => {
+    t.true(Boolean(base.network.identity.root))
+    t.true(Boolean(base.data.root))
+    return {
+      test: {
+        root: base.data.root
+      }
+    }
+  })
+  t.true(Boolean(conf.test.root) && (conf.test.root === conf.data.root))
 })


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Enabled conf function passing for easy access to base rc
  - Fixed issue where network.identity.root wouldn't base data.root
  - Removed state (ara-runtime-config shouldn't store state)
